### PR TITLE
type changes for GPU compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8'
+          - '1.11.5'
         os:
           - ubuntu-latest
         arch:
@@ -29,16 +29,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ performance. Possible choices include `k = r - 10` and `k = round(Int, 0.95*r)`.
 Sketches allow for faster (approximate) multiplication (`*` and `mul!`) and are
 used to construct preconditioners.
 
+If passing a matrix-free operator A, you can set the type of the cache as a keyword argument, 
+`NystromSketch(A, r::Int; n=nothing, S=Array{Float64,2})`.
+
 ### Positive Semidefinite Matrices: Nyström Sketch [2, Alg. 16]
 ```julia
 using RandomizedPreconditioners

--- a/src/eig.jl
+++ b/src/eig.jl
@@ -46,7 +46,7 @@ function eig_lanczos(
     tol=1e-12, 
     eigtype=1, 
     orthogonalize=false
-) where {T}
+)
     n = size(M, 1)
     iszero(q) && (q = ceil(Int, 20*log(n)))
     max_iters = min(q, n-1)

--- a/src/preconditioner.jl
+++ b/src/preconditioner.jl
@@ -3,13 +3,16 @@ abstract type Preconditioner{T} end
 # ------------------------------------------------------------------------------
 # |                           Nystrom Preconditioner                           |
 # ------------------------------------------------------------------------------
-mutable struct NystromPreconditioner{T <: Real} <: Preconditioner{T}
+mutable struct NystromPreconditioner{T <: Real, V <: AbstractVector{T}} <: Preconditioner{T}
     A_nys::NystromSketch{T}
     λ::T
     μ::T
-    cache::Vector{T}
-    function NystromPreconditioner(A_nys::NystromSketch{T}, μ::T) where {T <: Real}
-        return new{T}(A_nys, A_nys.Λ.diag[end], μ, zeros(rank(A_nys)))
+    cache::V
+    function NystromPreconditioner(A_nys::NystromSketch{T,AT,V}, μ::T) where {T <: Real, AT, V}
+        A_nys_Λ_diag_end = first(collect(A_nys.Λ.diag[end:end]))  # bring to CPU if needed
+        cache = V(undef, rank(A_nys))
+        fill!(cache, zero(T))
+        return new{T,V}(A_nys, A_nys_Λ_diag_end, μ, cache)
     end
 end
 function Matrix(P::NystromPreconditioner)
@@ -22,7 +25,7 @@ end
 # We care about applying P⁻¹
 # P⁻¹x = U*(λ + μ)*(Λ + μI)⁻¹*Uᵀ*x + (I - UUᵀ)*x
 #      = x - U*((λ + μ)*(Λ + μI)⁻¹ + I)*Uᵀ*x
-function LinearAlgebra.ldiv!(y::Vector{T}, P::NystromPreconditioner{T}, x::Vector{T}) where {T <: Real}
+function LinearAlgebra.ldiv!(y::AbstractVector{T}, P::NystromPreconditioner{T}, x::AbstractVector{T}) where {T <: Real}
     length(y) != length(x) && error(DimensionMismatch())
     mul!(P.cache, P.A_nys.U', x)
     @. P.cache *= (P.λ + P.μ) * 1 / (P.A_nys.Λ.diag + P.μ) - 1
@@ -31,16 +34,16 @@ function LinearAlgebra.ldiv!(y::Vector{T}, P::NystromPreconditioner{T}, x::Vecto
     return nothing
 end
 
-function LinearAlgebra.ldiv!(P::NystromPreconditioner{T}, x::Vector{T}) where {T <: Real} 
+function LinearAlgebra.ldiv!(P::NystromPreconditioner{T}, x::AbstractVector{T}) where {T <: Real} 
     mul!(P.cache, P.A_nys.U', x)
     @. P.cache *= (P.λ + P.μ) / (P.A_nys.Λ.diag + P.μ) - one(T)
     x .+= P.A_nys.U*P.cache
     return nothing
 end
 
-function LinearAlgebra.:\(P::NystromPreconditioner{T}, x::Vector{T}) where {T <: Real} 
+function LinearAlgebra.:\(P::NystromPreconditioner{T}, x::AbstractVector{T}) where {T <: Real} 
     n = size(P, 1)
-    y = zeros(n)
+    y = similar(x, n)
     ldiv!(y, P, x)
     return y
 end

--- a/src/sketch.jl
+++ b/src/sketch.jl
@@ -23,7 +23,7 @@ end
 function NystromSketch(A::AbstractMatrix{T}, k::Int, r::Int; check=false, q=0, Ω=nothing) where {T <: Real}
     check && check_psd(A)
     n = size(A, 1)
-    Y = zeros(n, r)
+    Y = similar(A, n, r)
     
     ν = sqrt(n)*eps(norm(A))                    #TODO: revisit this choice
     A[diagind(A)] .+= ν
@@ -31,7 +31,7 @@ function NystromSketch(A::AbstractMatrix{T}, k::Int, r::Int; check=false, q=0, �
     isnothing(Ω) && (Ω = GaussianTestMatrix(n, r))
     rangefinder!(Y, A, Ω; q=0, Z=nothing, orthogonalize=false)
     A[diagind(A)] .-= ν
-    Z = zeros(r, r)
+    Z = similar(A, r, r)
     mul!(Z, Ω', Y)
 
     B = Y / cholesky(Symmetric(Z)).U
@@ -77,8 +77,8 @@ end
 # When you want to skecth M = AᵀA
 function NystromSketch_ATA(A::AbstractMatrix{T}, k::Int, r::Int) where {T}
     m, n = size(A)
-    Y = zeros(n, r)
-    cache = zeros(m, r)
+    Y = similar(A, n, r)
+    cache = similar(A, m, r)
     
     Ω = 1/sqrt(n) * randn(n, r)
     mul!(cache, A, Ω)
@@ -87,7 +87,7 @@ function NystromSketch_ATA(A::AbstractMatrix{T}, k::Int, r::Int) where {T}
     ν = sqrt(n)*eps(norm(Y))
     @. Y = Y + ν*Ω
 
-    Z = zeros(r, r)
+    Z = similar(A, r, r)
     mul!(Z, Ω', Y)
     # Z[diagind(Z)] .+= ν                 # for numerical stability
 
@@ -104,7 +104,7 @@ function NystromSketch_ATA!(Y::Matrix{T}, Ω::Matrix{T}, A::AbstractMatrix{T}, r
     m, n = size(A)
     r1 = r - r0
     new_inds = r0+1:r0+r1
-    cache = zeros(m, r1)
+    cache = similar(Y, m, r1)
 
     @views randn!(Ω[:, new_inds])
     @views Ω[:, new_inds] ./= sqrt(n)
@@ -113,7 +113,7 @@ function NystromSketch_ATA!(Y::Matrix{T}, Ω::Matrix{T}, A::AbstractMatrix{T}, r
     @views mul!(Y[:, new_inds], A', cache)
     
     @views ν = sqrt(n)*eps(norm(Y[:, 1:r]))
-    Z = zeros(r, r)
+    Z = similar(Y, r, r)
     @views mul!(Z, Ω[:, 1:r]', Y[:, 1:r])
     Z[diagind(Z)] .+= ν                 # for numerical stability
 
@@ -152,7 +152,7 @@ end
 Matrix(Anys::Union{NystromSketch, EigenSketch}) = Anys.U*Anys.Λ*Anys.U'
 LinearAlgebra.eigvals(Anys::Union{NystromSketch, EigenSketch}) = Anys.Λ.diag    # decreasing order
 
-function LinearAlgebra.mul!(y, Anys::Union{NystromSketch, EigenSketch}, x; cache=zeros(rank(Anys)))
+function LinearAlgebra.mul!(y, Anys::Union{NystromSketch, EigenSketch}, x; cache=similar(x, rank(Anys)))
     length(y) != length(x) || length(y) != size(Anys, 1) && error(DimensionMismatch())
     r = rank(Anys)
     @views mul!(cache[1:r], Anys.U', x)
@@ -163,7 +163,7 @@ end
 
 function LinearAlgebra.:*(Anys::Union{NystromSketch, EigenSketch}, x::AbstractVector)
     n = size(Anys, 1)
-    y = zeros(n)
+    y = similar(x, n)
     mul!(y, Anys, x)
     return y
 end
@@ -239,7 +239,7 @@ function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, Ahat::RandomizedSVD
     show(io, mime, Ahat.V)
 end
 
-function LinearAlgebra.mul!(y, Ahat::RandomizedSVD, x; cache=zeros(rank(Ahat)))
+function LinearAlgebra.mul!(y, Ahat::RandomizedSVD, x; cache=similar(x, rank(Ahat)))
     length(x) != size(Ahat, 2) || length(y) != size(Ahat, 1) && error(DimensionMismatch())
     r = rank(Ahat)
     @views mul!(cache[1:r], Ahat.V', x)
@@ -248,7 +248,7 @@ function LinearAlgebra.mul!(y, Ahat::RandomizedSVD, x; cache=zeros(rank(Ahat)))
     return nothing
 end
 
-function LinearAlgebra.mul!(x, Ahat_::Adjoint{T, RandomizedSVD{T}}, y; cache=zeros(rank(Ahat))) where {T}
+function LinearAlgebra.mul!(x, Ahat_::Adjoint{T, RandomizedSVD{T}}, y; cache=similar(y, rank(Ahat))) where {T}
     Ahat = parent(Ahat_)
     length(x) != size(Ahat, 2) || length(y) != size(Ahat, 1) && error(DimensionMismatch())
     r = rank(Ahat)
@@ -259,7 +259,7 @@ function LinearAlgebra.mul!(x, Ahat_::Adjoint{T, RandomizedSVD{T}}, y; cache=zer
 end
 
 function LinearAlgebra.:*(Ahat::Union{Adjoint{T, RandomizedSVD{T}}, RandomizedSVD{T}}, x::AbstractVector) where {T}
-    y = zeros(size(Ahat, 1))
+    y = similar(x, size(Ahat, 1))
     mul!(y, Ahat, x)
     return y
 end


### PR DESCRIPTION
I've made a small set of non-breaking changes to be able to specify the cache type for NystromSketch and replace various `zeros` calls with `similar` or undef initializers. I've added a line to the README, but I've tried to keep this PR a bit limited (so the adaptive Nystrom sketch has not been updated, but it'd be easy to make that work).

Later, in GeNIOS one can call for example:

```julia
# obtain 2D type of an instance of a 1D vector type, i.e. Vector{T} -> Matrix{T}
_promote_1D_vector_type(x::AbstractVector) = typeof(reshape(x, (length(x), 1)))
```

```julia
∇²fx_nys = RP.NystromSketch(solver.lhs_op.Hf_xk, options.init_sketch_size;
    n=solver.lhs_op.n, S=_promote_1D_vector_type(solver.cache.vm))
```